### PR TITLE
Use shared llvm libs instead of static libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to compile, [LLVM](http://llvm.org/) 14, [HTSlib](https://github.com/sa
 
 On Debian/Ubuntu, these can be installed by:
 
-    sudo apt-get install autotools-dev build-essential libhts-dev libtool libpcre++-dev llvm-dev pkg-config uuid-dev zlib1g-dev
+    sudo apt-get install autotools-dev build-essential libhts-dev libtool libpcre++-dev llvm-dev pkg-config uuid-dev zlib1g-dev libossp-uuid-dev
 
 On RedHat/Fedora, these can be installed by:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ In the source directory,
 
     autoreconf -i && ./configure && make && sudo make install
 
+If you do not have static LLVM libraries available and the configure step above fails, try
+
+    autoreconf -i && ./configure --enable-static=no --enable-static-llvm=no && make && sudo make install
+
 ## The Query Language
 
 The language consists of a number of predicates, things which match sequences, and connectives, which compose predicates.


### PR DESCRIPTION
The configure script fails if it does not find static LLVM libs. One can at least force it to accept dynamically shared libs via configure switches. See https://github.com/BoutrosLaboratory/bamql/issues/14 for previous discussion.